### PR TITLE
Remove redundant restore step from Dockerfile

### DIFF
--- a/src/services/AcademyIO.Payments.API/Dockerfile
+++ b/src/services/AcademyIO.Payments.API/Dockerfile
@@ -23,8 +23,7 @@ COPY ["src/", "src/"]
 # Publish the application.
 WORKDIR "/src/src/services/AcademyIO.Payments.API"
 # Ensure packages and project references are restored before publishing
-RUN dotnet restore "AcademyIO.Payments.API.csproj" \
-    && dotnet publish "AcademyIO.Payments.API.csproj" -c Release -o /app/publish /p:UseAppHost=false -v minimal
+RUN dotnet publish "AcademyIO.Payments.API.csproj" -c Release -o /app/publish /p:UseAppHost=false -v minimal
 
 # Stage 2: Final - Creates the final runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final


### PR DESCRIPTION
Simplifies the build process by removing the explicit 'dotnet restore' command before publishing. The 'dotnet publish' command implicitly restores dependencies, making the separate restore step unnecessary.