### PR TITLE
Add missing using directives to API service files

### DIFF
--- a/src/services/AcademyIO.Payments.API/Configuration/SwaggerConfig.cs
+++ b/src/services/AcademyIO.Payments.API/Configuration/SwaggerConfig.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.OpenApi.Models;
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 
 namespace AcademyIO.Payments.API.Configuration
 {

--- a/src/services/AcademyIO.Payments.API/Services/PaymentRequestedIntegrationHandler.cs
+++ b/src/services/AcademyIO.Payments.API/Services/PaymentRequestedIntegrationHandler.cs
@@ -1,4 +1,10 @@
-﻿using AcademyIO.Core.Messages.Integration;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using AcademyIO.Core.Messages;
+using AcademyIO.Core.Messages.Integration;
 using AcademyIO.Courses.API.Application.Commands;
 using AcademyIO.MessageBus;
 using FluentValidation.Results;
@@ -52,7 +58,7 @@ namespace AcademyIO.Payments.API.Services
                 sucesso = await mediator.Send(command);
             }
             if (!sucesso)
-                validationResult.Errors.Add(new ValidationFailure() { ErrorMessage = "Falha ao realizar pagamento." });
+                validationResult.Errors.Add(new FluentValidation.Results.ValidationFailure() { ErrorMessage = "Falha ao realizar pagamento." });
             return new ResponseMessage(validationResult);
         }
     }


### PR DESCRIPTION
Added necessary using statements for System, threading, tasks, and ASP.NET Core dependencies in SwaggerConfig.cs and PaymentRequestedIntegrationHandler.cs to resolve missing references and improve code clarity.